### PR TITLE
ReadOnly datasource should be left out of chained transaction manager

### DIFF
--- a/grails-core/src/main/groovy/org/grails/transaction/ChainedTransactionManagerPostProcessor.java
+++ b/grails-core/src/main/groovy/org/grails/transaction/ChainedTransactionManagerPostProcessor.java
@@ -183,7 +183,10 @@ public class ChainedTransactionManagerPostProcessor implements BeanDefinitionReg
         }
         Boolean transactional = config.getProperty(DATA_SOURCES_PREFIX + suffix + "." + TRANSACTIONAL, Boolean.class, null);
         if(transactional == null) {
-            transactional =  config.getProperty(DATA_SOURCES_PREFIX + suffix + "." + READONLY, Boolean.class, null);
+            Boolean isReadOnly =  config.getProperty(DATA_SOURCES_PREFIX + suffix + "." + READONLY, Boolean.class, null);
+            if (isReadOnly != null && isReadOnly == true) {
+                transactional = false
+            }
         }
         if(transactional != null){
             return !transactional;


### PR DESCRIPTION
Datasources with readOnly = true will also be left out of the chained transaction manager, see:

http://docs.grails.org/latest/guide/conf.html#multipleDatasources